### PR TITLE
Allow to define start row for dataProvider model.

### DIFF
--- a/src/Spreadsheet.php
+++ b/src/Spreadsheet.php
@@ -367,7 +367,7 @@ class Spreadsheet extends Component
             $document->getActiveSheet()->setTitle($this->title);
         }
 
-        $this->rowIndex = 1;
+        $this->rowIndex = (isset($this->rowIndex) ? $this->rowIndex : 1);
 
         $columnsInitialized = false;
         $modelIndex = 0;


### PR DESCRIPTION
# Example:
$exporter = (new Spreadsheet([
                'rowIndex' => 5,
                'title' => 'Groups',
                'dataProvider' => new ActiveDataProvider([
                    'query' => $subjectModel,
                ]),
                'columns' => [
                    ...
                ]
]))->render();